### PR TITLE
remove typo & correct the hyperlink

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -166,7 +166,7 @@
             <br>
             <h5><strong> Google 學生開發者社團 Google Developer Student Clubs Taiwan & Hong Kong </strong></h5>
             <br>
-            <p>合作聯繫:<br><a href="mailto://contact@sitcon.org">contact@sitcon.org</a> </p>
+            <p>合作聯繫:<br><a href="mailto:contact@sitcon.org">contact@sitcon.org</a> </p>
             <p>{{ new Date().getFullYear() }} — <strong>SITCON X GDSC</strong></p>
           </div>
         </div>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -166,7 +166,7 @@
             <br>
             <h5><strong> Google 學生開發者社團 Google Developer Student Clubs Taiwan & Hong Kong </strong></h5>
             <br>
-            <p>合作聯繫:<br><a href="mailto:contact@sitcon.org">contact@sitcon.org</a> </p>
+            <p>合作聯繫：<br><a href="mailto:contact@sitcon.org">contact@sitcon.org</a> </p>
             <p>{{ new Date().getFullYear() }} — <strong>SITCON X GDSC</strong></p>
           </div>
         </div>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -164,7 +164,7 @@
             <br>
             <h5><strong> 學生計算機年會 Students' Information Technology Conference </strong></h5>
             <br>
-            <h5><strong> Google 學生開發者社團 Google Developer Student Clubs Taiwan & Hong Kong </strong>st></h5>
+            <h5><strong> Google 學生開發者社團 Google Developer Student Clubs Taiwan & Hong Kong </strong></h5>
             <br>
             <p>合作聯繫:<br><a href="mailto://contact@sitcon.org">contact@sitcon.org</a> </p>
             <p>{{ new Date().getFullYear() }} — <strong>SITCON X GDSC</strong></p>


### PR DESCRIPTION
Hello,

I would like to bring to your attention a couple of minor errors I found on the official website, which I have taken the liberty of fixing:

- (https://github.com/sitcon-tw/2023/commit/c4feeaeaa787925d0cce2fd314d1a74e5b8b7d50) Remove redundant typo.
- (https://github.com/sitcon-tw/2023/commit/5e559e142f97418091e810b988d3d06fd8f792b5) Fix the mailto link, as the original link would cause users to send mail to `//contact@sitcon.org`.

I also have a small question regarding the footer of the website.

I noticed that the year is obtained using the Javascript code `new Date().getFullYear()`. While this correctly displays the current year as 2023, I'm concerned that it will not update correctly when the year changes. Would you like to check it?
https://github.com/sitcon-tw/2023/blob/4f096b76ddde047895ff9935d42292bcd97e0a71/src/pages/index.vue#L170

Thanks!