### PR TITLE
Add rel="me" to the footer Mastodon link

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -146,7 +146,7 @@
           <div class="footersectioncontecttext">
             <span>
               <a color="white" v-for="icon in iconLinks" :key="icon" :class="icon.icon" :icon="icon.icon"
-                :href="icon.link" class="btnicon" variant="text">
+                :href="icon.link" :rel="icon.rel" class="btnicon" variant="text">
               </a>
             </span>
             <br>
@@ -245,7 +245,8 @@ export default {
       {
         name: "Mastodon",
         link: "https://g0v.social/@sitcontw",
-        icon: "bi-mastodon"
+        icon: "bi-mastodon",
+        rel: "me"
       }
     ],
     years: [2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022]


### PR DESCRIPTION
This enables identity verification on Mastodon by adding the `rel="me"` attribute.

Some notable examples of this attribute in the wild include [@wikipedia@wikis.world](https://wikis.world/@wikipedia) and [@mozilla@mozilla.social](https://mozilla.social/@mozilla).  Notice how the links on their Mastodon profiles are accompanied by green checkmarks.  See https://joinmastodon.org/verification and https://microformats.org/wiki/rel-me for more info.

To gain the green checkmark, the link would need to be manually removed and added back by whomever in charge of the Mastodon account.